### PR TITLE
Fix tooltip margin mixin for latest Sass version

### DIFF
--- a/src/hint-always.scss
+++ b/src/hint-always.scss
@@ -8,15 +8,6 @@
  * 	
  */
 
-// mixin to set margin on tooltip using translate transform
-@mixin set-margin($property, $transitionDirection) {
-	&:after, &:before {
-		-webkit-transform: #{$property}($transitionDirection * $transitionDistance);
-		-moz-transform: #{$property}($transitionDirection * $transitionDistance);
-		transform: #{$property}($transitionDirection * $transitionDistance);
-	}
-}
-
 .hint--always {
 	&:after, &:before {
 		opacity: 1;

--- a/src/hint-mixins.scss
+++ b/src/hint-mixins.scss
@@ -19,3 +19,14 @@
 		}
 	}
 }
+
+// mixin to set margin on tooltip using translate transform
+@mixin set-margin($property, $transitionDirection) {
+	$value: unquote("#{$property}(#{$transitionDistance * $transitionDirection})");
+	&:after,
+	&:before {
+		-webkit-transform: $value;
+		-moz-transform: $value;
+		transform: $value;
+	}
+}

--- a/src/hint-position.scss
+++ b/src/hint-position.scss
@@ -27,9 +27,7 @@
 	}
 
 	&:hover:before, &:hover:after {
-		-webkit-transform: translateY($transitionDirection * $transitionDistance);
-		-moz-transform: translateY($transitionDirection * $transitionDistance);
-		transform: translateY($transitionDirection * $transitionDistance);
+		@include set-margin('translateY', $transitionDirection);
 	}
 }
 
@@ -52,9 +50,7 @@
 	}
 
 	&:hover:before, &:hover:after {
-		-webkit-transform: translateX($transitionDirection * $transitionDistance);
-		-moz-transform: translateX($transitionDirection * $transitionDistance);
-		transform: translateX($transitionDirection * $transitionDistance);
+		@include set-margin('translateX', $transitionDirection);
 	}
 }
 


### PR DESCRIPTION
Latest version of Sass change the way parentheses are handled, which
generate properties like `transform: translateY-8px`.
I also move the mixin to the mixins file + reuse the mixin where it's appropriate.
