### PR TITLE
Don't ignore src in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
 	"author": "Kushagra Gour",
 	"ignore": [
 		"CONTRIBUTING.md",
-		"src/",
 		"Gruntfile.js"
 	]
 }


### PR DESCRIPTION
Thanks for adding a bower.json file in 1.3.

But before 1.3, using this repo with bower and the v1.2.2 tags meant that the `src` directory was included.

That's useful for those of us who also use Sass as we can then manually include the files we want or adjust variables.

So here's a change to add `src` back.
