### PR TITLE
Increased border due to a bug in Google Chrome browser in OSX

### DIFF
--- a/hint.css
+++ b/hint.css
@@ -53,7 +53,7 @@
     content: '';
     position: absolute;
     background: transparent;
-    border: 6px solid transparent;
+    border: 7px solid transparent;
     z-index: 1000001; }
   .hint:after, [data-hint]:after {
     content: attr(data-hint);


### PR DESCRIPTION
I've changed the border size to 7px because in Google chrome i was getting 1px lapse between the arrow and the body.
