### PR TITLE
Added keywords to bower.json for better SEO

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,5 +6,11 @@
 	"ignore": [
 		"CONTRIBUTING.md",
 		"Gruntfile.js"
+	],
+	"keywords": [
+		"hint",
+		"tooltip",
+		"tooltips",
+		"ui"
 	]
 }


### PR DESCRIPTION
When searching through the bower repository using the term "tooltip", this library does not even appear on the first page of results, so I added the keywords which appear in the top tooltip and popup libraries on bower to help this library appear in more searches. It's an awesome library and deserves the exposure!
