### PR TITLE
The H in GitHub should be capitalized in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you find this useful and want to show some love & encouragement, I am on [Git
 
 Get the library using one of the following ways:
 
-1. **Github**
+1. **GitHub**
 
  Full build
  - [unminified] : https://raw.github.com/chinchang/hint.css/master/hint.css


### PR DESCRIPTION
This is a small typo fix.