### PR TITLE
Allow the hint.css package in npm to expose CSS 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "title": "Hint.css",
   "description": "A tooltip library in CSS for your lovely websites.",
   "version": "1.3.6",
+  "style": "hint.css",
   "homepage": "http://kushagragour.in/lab/hint/",
   "author": {
     "name": "Kushagra Gour",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "Hint.css",
   "description": "A tooltip library in CSS for your lovely websites.",
   "version": "1.3.6",
-  "style": "hint.css",
+  "style": "hint.min.css",
   "homepage": "http://kushagragour.in/lab/hint/",
   "author": {
     "name": "Kushagra Gour",


### PR DESCRIPTION
Many modules are starting to expose their css entry files in their package.json files via the `style` field . This allows tools like [`npm-css`](https://github.com/defunctzombie/npm-css), [`rework-npm`](https://github.com/reworkcss/rework-npm) and [`npm-less`](https://github.com/Raynos/npm-less) to import hint.css CSS from the node_modules directory. 

Also this plays well with browserify plugins ( like [`parcelify`](https://github.com/rotundasoftware/parcelify)) which helps in bundling CSS together from npm packages