### PR TITLE
Updated CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,15 @@
 
 **Hint.css** uses [Grunt](http://gruntjs.com/) for the build process which you need to have installed on your system.
 
-Also there are two additional Grunt tasks required to build the library:
+Also there are four additional Grunt tasks required to build the library:
 
 1. [grunt-contrib-cssmin](https://npmjs.org/package/grunt-contrib-cssmin)
 
 2. [grunt-contrib-sass](https://www.npmjs.com/package/grunt-contrib-sass)
+
+3. [grunt-contrib-concat](https://www.npmjs.com/package/grunt-contrib-concat)
+
+4. [grunt-contrib-watch](https://www.npmjs.com/package/grunt-contrib-watch)
 
 To install all the dependencies, run `npm install`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Also there are two additional Grunt tasks required to build the library:
 
 1. [grunt-contrib-cssmin](https://npmjs.org/package/grunt-contrib-cssmin)
 
-2. [grunt-sass](https://npmjs.org/package/grunt-sass)
+2. [grunt-contrib-sass](https://www.npmjs.com/package/grunt-contrib-sass)
 
 To install all the dependencies, run `npm install`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 Also there are two additional Grunt tasks required to build the library:
 
-1. [grunt-contrib-mincss](https://npmjs.org/package/grunt-contrib-mincss)
+1. [grunt-contrib-cssmin](https://npmjs.org/package/grunt-contrib-cssmin)
 
 2. [grunt-sass](https://npmjs.org/package/grunt-sass)
 


### PR DESCRIPTION
Renamed grunt-contrib-mincss to grunt-contrib-cssmin as https://www.npmjs.com/package/grunt-contrib-mincss is now https://www.npmjs.com/package/grunt-contrib-cssmin

Replaced reference of grunt-sass with grunt-contrib-sass as plugins were switched in afefceef542c0e7127eeebfe96c9a26bd7d596f5

Add reference to other grunt plugins being used.