### PR TITLE
Replaces deprecated licenses field with new license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,7 @@
   "bugs": {
     "url": "https://github.com/chinchang/hint.css/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/chinchang/hint.css/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "SEE LICENSE IN LICENSE-MIT",
   "keywords": [
     "tooltip",
     "ui",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/chinchang/hint.css/issues"
   },
-  "license": "SEE LICENSE IN LICENSE-MIT",
+  "license": "MIT",
   "keywords": [
     "tooltip",
     "ui",


### PR DESCRIPTION
This fixes the warning thrown when doing ``npm install``

```bash
npm WARN hint@1.3.6 No license field.
```

Refer to https://docs.npmjs.com/files/package.json#license