### PR TITLE
Add support for jit-grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,10 +75,7 @@ module.exports = function(grunt) {
 	});
 
 	// Dependencies
-	grunt.loadNpmTasks('grunt-contrib-sass');
-	grunt.loadNpmTasks('grunt-contrib-cssmin');
-	grunt.loadNpmTasks('grunt-contrib-concat');
-	grunt.loadNpmTasks('grunt-contrib-watch');
+	require('jit-grunt')(grunt);
 
 	// Default task.
 	grunt.registerTask('default', 'sass');

--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
     "hint"
   ],
   "devDependencies": {
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-sass": "~0.4.1",
     "grunt": "~0.4.1",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-cssmin": "~0.12.3",
+    "grunt-contrib-sass": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-contrib-cssmin": "~0.12.3"
+    "jit-grunt": "^0.9.1"
   }
 }


### PR DESCRIPTION
Just In Time plugin loader for Grunt - https://www.npmjs.com/package/jit-grunt

Improves build time of Grunt tasks by loading plugins as and when they are needed rather than loading them all upfront before executing 