### PR TITLE
Added support for :focus

### DIFF
--- a/src/hint-core.scss
+++ b/src/hint-core.scss
@@ -34,13 +34,15 @@
 		@include vendor('transition-delay', $hideDelay);
 	}
 
-	&:hover:before, &:hover:after {
+	&:hover:before, &:hover:after,
+	&:focus:before, &:focus:after {
 		visibility: visible;
 		opacity: 1;
 	}
 
-	&:hover:before, &:hover:after {
-		// $showDelay will apply as soon as element is hovered.
+	&:hover:before, &:hover:after,
+	&:focus:before, &:focus:after {
+		// $showDelay will apply as soon as element is hovered or focused.
 		@include vendor('transition-delay', $showDelay);
 	}
 

--- a/src/hint-core.scss
+++ b/src/hint-core.scss
@@ -35,13 +35,13 @@
 	}
 
 	&:hover:before, &:hover:after,
-	&:focus:before, &:focus:after {
+	&:not(button):focus:before, &:not(button):focus:after {
 		visibility: visible;
 		opacity: 1;
 	}
 
 	&:hover:before, &:hover:after,
-	&:focus:before, &:focus:after {
+	&:not(button):focus:before, &:not(button):focus:after {
 		// $showDelay will apply as soon as element is hovered or focused.
 		@include vendor('transition-delay', $showDelay);
 	}


### PR DESCRIPTION
Hints wasn't showing up when focused, which made them inaccessible by keyboard navigation. This fix will also make them show up on _:focus_, not only on _:hover.