### PR TITLE
Prefix all variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you are already using v1.x, you may need to tweak certain position classes be
 
 Don't like BEM naming (`hint--`) or want to use your own prefix for the class names?
 
-Simply update `src/hint-variables.scss` and change the `$prefix` variable.
+Simply update `src/hint-variables.scss` and change the `$hint-prefix` variable.
 To generate the css file, please read the [contributing page](./CONTRIBUTING.md).
 
 ## Who's Using This?

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you are already using v1.x, you may need to tweak certain position classes be
 
 Don't like BEM naming (`hint--`) or want to use your own prefix for the class names?
 
-Simply update `src/hint-variables.scss` and change the `$hint-prefix` variable.
+Simply update `src/hint-variables.scss` and change the `$hintPrefix` variable.
 To generate the css file, please read the [contributing page](./CONTRIBUTING.md).
 
 ## Who's Using This?

--- a/src/hint-always.scss
+++ b/src/hint-always.scss
@@ -8,13 +8,13 @@
  *
  */
 
-.#{$hint-prefix}always {
+.#{$hintPrefix}always {
 	&:after, &:before {
 		opacity: 1;
 		visibility: visible;
 	}
 
-	&.#{$hint-prefix}top {
+	&.#{$hintPrefix}top {
 		@include set-margin('translateY', -1, -50%);
 
 		&-left {
@@ -25,7 +25,7 @@
 		}
 	}
 
-	&.#{$hint-prefix}bottom {
+	&.#{$hintPrefix}bottom {
 		@include set-margin('translateY', 1, -50%);
 		&-left {
 			@include set-margin('translateY', 1, -100%);
@@ -35,11 +35,11 @@
 		}
 	}
 
-	&.#{$hint-prefix}left {
+	&.#{$hintPrefix}left {
 		@include set-margin('translateX', -1);
 	}
 
-	&.#{$hint-prefix}right {
+	&.#{$hintPrefix}right {
 		@include set-margin('translateX', 1);
 	}
 }

--- a/src/hint-always.scss
+++ b/src/hint-always.scss
@@ -8,13 +8,13 @@
  *
  */
 
-.#{$prefix}always {
+.#{$hint-prefix}always {
 	&:after, &:before {
 		opacity: 1;
 		visibility: visible;
 	}
 
-	&.#{$prefix}top {
+	&.#{$hint-prefix}top {
 		@include set-margin('translateY', -1, -50%);
 
 		&-left {
@@ -25,7 +25,7 @@
 		}
 	}
 
-	&.#{$prefix}bottom {
+	&.#{$hint-prefix}bottom {
 		@include set-margin('translateY', 1, -50%);
 		&-left {
 			@include set-margin('translateY', 1, -100%);
@@ -35,11 +35,11 @@
 		}
 	}
 
-	&.#{$prefix}left {
+	&.#{$hint-prefix}left {
 		@include set-margin('translateX', -1);
 	}
 
-	&.#{$prefix}right {
+	&.#{$hint-prefix}right {
 		@include set-margin('translateX', 1);
 	}
 }

--- a/src/hint-color-types.scss
+++ b/src/hint-color-types.scss
@@ -16,7 +16,7 @@
 @mixin hint-type($color) {
 	&:after {
 		background-color: $color;
-		text-shadow: 0 -1px 0px darken($color, $hint-textShadowDarkenAmount);
+		text-shadow: 0 -1px 0px darken($color, $hintTextShadowDarkenAmount);
 	}
 
 	// generate arrow color style
@@ -26,27 +26,27 @@
 /**
  * Error
  */
-.#{$hint-prefix}error {
-	@include hint-type($hint-errorColor);
+.#{$hintPrefix}error {
+	@include hint-type($hintErrorColor);
 }
 
 /**
  * Warning
  */
-.#{$hint-prefix}warning {
-	@include hint-type($hint-warningColor)
+.#{$hintPrefix}warning {
+	@include hint-type($hintWarningColor)
 }
 
 /**
  * Info
  */
-.#{$hint-prefix}info {
-	@include hint-type($hint-infoColor)
+.#{$hintPrefix}info {
+	@include hint-type($hintInfoColor)
 }
 
 /**
  * Success
  */
-.#{$hint-prefix}success {
-	@include hint-type($hint-successColor)
+.#{$hintPrefix}success {
+	@include hint-type($hintSuccessColor)
 }

--- a/src/hint-color-types.scss
+++ b/src/hint-color-types.scss
@@ -16,7 +16,7 @@
 @mixin hint-type($color) {
 	&:after {
 		background-color: $color;
-		text-shadow: 0 -1px 0px darken($color, $textShadowDarkenAmount);
+		text-shadow: 0 -1px 0px darken($color, $hint-textShadowDarkenAmount);
 	}
 
 	// generate arrow color style
@@ -26,27 +26,27 @@
 /**
  * Error
  */
-.#{$prefix}error {
-	@include hint-type($errorColor);
+.#{$hint-prefix}error {
+	@include hint-type($hint-errorColor);
 }
 
 /**
  * Warning
  */
-.#{$prefix}warning {
-	@include hint-type($warningColor)
+.#{$hint-prefix}warning {
+	@include hint-type($hint-warningColor)
 }
 
 /**
  * Info
  */
-.#{$prefix}info {
-	@include hint-type($infoColor)
+.#{$hint-prefix}info {
+	@include hint-type($hint-infoColor)
 }
 
 /**
  * Success
  */
-.#{$prefix}success {
-	@include hint-type($successColor)
+.#{$hint-prefix}success {
+	@include hint-type($hint-successColor)
 }

--- a/src/hint-core.scss
+++ b/src/hint-core.scss
@@ -26,12 +26,12 @@
 		// shows the tooltip.
 		visibility: hidden;
 		opacity: 0;
-		z-index: $hint-zIndex;
+		z-index: $hintZIndex;
 		// shouldn't receive pointer events, otherwise even hovering tooltip will make it appear
 		pointer-events: none;
 
 		@include vendor('transition', 0.3s ease);
-		@include vendor('transition-delay', $hint-hideDelay);
+		@include vendor('transition-delay', $hintHideDelay);
 	}
 
 	&:hover:before, &:hover:after {
@@ -40,8 +40,8 @@
 	}
 
 	&:hover:before, &:hover:after {
-		// $hint-showDelay will apply as soon as element is hovered.
-		@include vendor('transition-delay', $hint-showDelay);
+		// $hintShowDelay will apply as soon as element is hovered.
+		@include vendor('transition-delay', $hintShowDelay);
 	}
 
 	/**
@@ -51,9 +51,9 @@
 		content: '';
 		position: absolute;
 		background: transparent;
-		border: $hint-arrowBorderWidth solid transparent;
+		border: $hintArrowBorderWidth solid transparent;
 		// move z-index 1 up than :after so that it shows over box-shadow
-		z-index: $hint-zIndex + 1;
+		z-index: $hintZIndex + 1;
 	}
 
 	/**
@@ -61,17 +61,17 @@
 	 */
 	&:after {
 		content: attr(data-hint); // The magic!
-		background: $hint-defaultColor;
+		background: $hintDefaultColor;
 		color: white;
-		padding: $hint-verticalPadding $hint-horizontalPadding;
-		font-size: $hint-fontSize;
-		line-height: $hint-fontSize; // Vertical centering.
+		padding: $hintVerticalPadding $hintHorizontalPadding;
+		font-size: $hintFontSize;
+		line-height: $hintFontSize; // Vertical centering.
 		white-space: nowrap; // Prevent breaking to new line.
 	}
 }
 
 [data-hint=''] {
 	&:before, &:after {
-		display: none!important;
+		display: none !important;
 	}
 }

--- a/src/hint-core.scss
+++ b/src/hint-core.scss
@@ -26,12 +26,12 @@
 		// shows the tooltip.
 		visibility: hidden;
 		opacity: 0;
-		z-index: $zIndex;
+		z-index: $hint-zIndex;
 		// shouldn't receive pointer events, otherwise even hovering tooltip will make it appear
 		pointer-events: none;
 
 		@include vendor('transition', 0.3s ease);
-		@include vendor('transition-delay', $hideDelay);
+		@include vendor('transition-delay', $hint-hideDelay);
 	}
 
 	&:hover:before, &:hover:after {
@@ -40,8 +40,8 @@
 	}
 
 	&:hover:before, &:hover:after {
-		// $showDelay will apply as soon as element is hovered.
-		@include vendor('transition-delay', $showDelay);
+		// $hint-showDelay will apply as soon as element is hovered.
+		@include vendor('transition-delay', $hint-showDelay);
 	}
 
 	/**
@@ -51,9 +51,9 @@
 		content: '';
 		position: absolute;
 		background: transparent;
-		border: $arrowBorderWidth solid transparent;
+		border: $hint-arrowBorderWidth solid transparent;
 		// move z-index 1 up than :after so that it shows over box-shadow
-		z-index: $zIndex + 1;
+		z-index: $hint-zIndex + 1;
 	}
 
 	/**
@@ -61,11 +61,11 @@
 	 */
 	&:after {
 		content: attr(data-hint); // The magic!
-		background: $defaultColor;
+		background: $hint-defaultColor;
 		color: white;
-		padding: $verticalPadding $horizontalPadding;
-		font-size: $fontSize;
-		line-height: $fontSize; // Vertical centering.
+		padding: $hint-verticalPadding $hint-horizontalPadding;
+		font-size: $hint-fontSize;
+		line-height: $hint-fontSize; // Vertical centering.
 		white-space: nowrap; // Prevent breaking to new line.
 	}
 }

--- a/src/hint-effects.scss
+++ b/src/hint-effects.scss
@@ -10,14 +10,14 @@
  */
 
 // Remove animation from tooltips.
-.#{$hint-prefix}no-animate {
+.#{$hintPrefix}no-animate {
 	&:before, &:after {
 		@include vendor('transition-duration', 0ms);
 	}
 }
 
 // Bounce effect in tooltips.
-.#{$hint-prefix}bounce {
+.#{$hintPrefix}bounce {
 	&:before, &:after {
 		-webkit-transition: opacity 0.3s ease, visibility 0.3s ease, -webkit-transform 0.3s cubic-bezier(.71,1.7,.77,1.24);
 		-moz-transition: opacity 0.3s ease, visibility 0.3s ease, -moz-transform 0.3s cubic-bezier(.71,1.7,.77,1.24);

--- a/src/hint-effects.scss
+++ b/src/hint-effects.scss
@@ -10,14 +10,14 @@
  */
 
 // Remove animation from tooltips.
-.#{$prefix}no-animate {
+.#{$hint-prefix}no-animate {
 	&:before, &:after {
 		@include vendor('transition-duration', 0ms);
 	}
 }
 
 // Bounce effect in tooltips.
-.#{$prefix}bounce {
+.#{$hint-prefix}bounce {
 	&:before, &:after {
 		-webkit-transition: opacity 0.3s ease, visibility 0.3s ease, -webkit-transform 0.3s cubic-bezier(.71,1.7,.77,1.24);
 		-moz-transition: opacity 0.3s ease, visibility 0.3s ease, -moz-transform 0.3s cubic-bezier(.71,1.7,.77,1.24);

--- a/src/hint-mixins.scss
+++ b/src/hint-mixins.scss
@@ -15,12 +15,12 @@
 		@if $position == top or $position == bottom {
 			// Loop further for classes like .top-left, bottom-right etc
 			@each $xDir in left, right {
-				&.#{$hint-prefix}#{$position}-#{$xDir}:before {
+				&.#{$hintPrefix}#{$position}-#{$xDir}:before {
 					border-#{$position}-color: $color;
 				}
 			}
 		}
-		&.#{$hint-prefix}#{$position}:before {
+		&.#{$hintPrefix}#{$position}:before {
 			border-#{$position}-color: $color;
 		}
 	}
@@ -29,7 +29,7 @@
 // mixin to set margin on tooltip using translate transform
 // $property
 @mixin set-margin($property, $transitionDirection, $translateX: 0) {
-	$value: unquote("#{$property}(#{$hint-transitionDistance * $transitionDirection})");
+	$value: unquote("#{$property}(#{$hintTransitionDistance * $transitionDirection})");
 	&:after, &:before {
 		@if $translateX != 0 {
 			@include vendor('transform', translateX($translateX) $value);

--- a/src/hint-mixins.scss
+++ b/src/hint-mixins.scss
@@ -15,12 +15,12 @@
 		@if $position == top or $position == bottom {
 			// Loop further for classes like .top-left, bottom-right etc
 			@each $xDir in left, right {
-				&.#{$prefix}#{$position}-#{$xDir}:before {
+				&.#{$hint-prefix}#{$position}-#{$xDir}:before {
 					border-#{$position}-color: $color;
 				}
 			}
 		}
-		&.#{$prefix}#{$position}:before {
+		&.#{$hint-prefix}#{$position}:before {
 			border-#{$position}-color: $color;
 		}
 	}
@@ -29,7 +29,7 @@
 // mixin to set margin on tooltip using translate transform
 // $property
 @mixin set-margin($property, $transitionDirection, $translateX: 0) {
-	$value: unquote("#{$property}(#{$transitionDistance * $transitionDirection})");
+	$value: unquote("#{$property}(#{$hint-transitionDistance * $transitionDirection})");
 	&:after, &:before {
 		@if $translateX != 0 {
 			@include vendor('transform', translateX($translateX) $value);

--- a/src/hint-position.scss
+++ b/src/hint-position.scss
@@ -13,7 +13,7 @@
 @mixin vertical-positioned-tooltip($propertyY, $transitionDirection, $xDirection:0) {
 	&:before {
 		// get the arrow out
-		margin-#{$propertyY}: -2 * $hint-arrowBorderWidth;
+		margin-#{$propertyY}: -2 * $hintArrowBorderWidth;
 	}
 
 	&:before, &:after {
@@ -36,7 +36,7 @@
 	&:after {
 		@if $xDirection != 0 {
 			// bring back the tooltip by some offset so that arrow doesn't stick at end
-			margin-left: -$xDirection * $hint-arrowOffsetX;
+			margin-left: -$xDirection * $hintArrowOffsetX;
 		}
 	}
 
@@ -48,14 +48,14 @@
 @mixin horizontal-positioned-tooltip($propertyX, $transitionDirection) {
 	&:before {
 		// get the arrow out
-		margin-#{$propertyX}: -2 * $hint-arrowBorderWidth;
+		margin-#{$propertyX}: -2 * $hintArrowBorderWidth;
 		// bring back to center
-		margin-bottom: -1 * $hint-arrowBorderWidth;
+		margin-bottom: -1 * $hintArrowBorderWidth;
 	}
 
 	&:after {
 		// bring back to center
-		margin-bottom: -1 * floor($hint-tooltipHeight / 2);
+		margin-bottom: -1 * floor($hintTooltipHeight / 2);
 	}
 
 	&:before, &:after {
@@ -72,40 +72,40 @@
 /**
  * set default color for tooltip arrows
  */
-@include arrow-border-color($hint-defaultColor);
+@include arrow-border-color($hintDefaultColor);
 
 /**
  * top tooltip
  */
-.#{$hint-prefix}top {
+.#{$hintPrefix}top {
 	@include vertical-positioned-tooltip('bottom', -1);
 }
 
 /**
  * bottom tooltip
  */
-.#{$hint-prefix}bottom {
+.#{$hintPrefix}bottom {
 	@include vertical-positioned-tooltip('top', 1);
 }
 
 /**
  * right tooltip
  */
-.#{$hint-prefix}right {
+.#{$hintPrefix}right {
 	@include horizontal-positioned-tooltip('left', 1);
 }
 
 /**
  * left tooltip
  */
-.#{$hint-prefix}left {
+.#{$hintPrefix}left {
 	@include horizontal-positioned-tooltip('right', -1);
 }
 
 /**
  * top-left tooltip
  */
-.#{$hint-prefix}top-left {
+.#{$hintPrefix}top-left {
 	@include vertical-positioned-tooltip('bottom', -1, -1);
 }
 
@@ -113,14 +113,14 @@
 /**
  * top-right tooltip
  */
-.#{$hint-prefix}top-right {
+.#{$hintPrefix}top-right {
 	@include vertical-positioned-tooltip('bottom', -1, 1);
 }
 
 /**
  * bottom-left tooltip
  */
-.#{$hint-prefix}bottom-left {
+.#{$hintPrefix}bottom-left {
 	@include vertical-positioned-tooltip('top', 1, -1);
 }
 
@@ -128,6 +128,6 @@
 /**
  * bottom-right tooltip
  */
-.#{$hint-prefix}bottom-right {
+.#{$hintPrefix}bottom-right {
 	@include vertical-positioned-tooltip('top', 1, 1);
 }

--- a/src/hint-position.scss
+++ b/src/hint-position.scss
@@ -13,7 +13,7 @@
 @mixin vertical-positioned-tooltip($propertyY, $transitionDirection, $xDirection:0) {
 	&:before {
 		// get the arrow out
-		margin-#{$propertyY}: -2 * $arrowBorderWidth;
+		margin-#{$propertyY}: -2 * $hint-arrowBorderWidth;
 	}
 
 	&:before, &:after {
@@ -36,7 +36,7 @@
 	&:after {
 		@if $xDirection != 0 {
 			// bring back the tooltip by some offset so that arrow doesn't stick at end
-			margin-left: -$xDirection * $arrowOffsetX;
+			margin-left: -$xDirection * $hint-arrowOffsetX;
 		}
 	}
 
@@ -48,14 +48,14 @@
 @mixin horizontal-positioned-tooltip($propertyX, $transitionDirection) {
 	&:before {
 		// get the arrow out
-		margin-#{$propertyX}: -2 * $arrowBorderWidth;
+		margin-#{$propertyX}: -2 * $hint-arrowBorderWidth;
 		// bring back to center
-		margin-bottom: -1 * $arrowBorderWidth;
+		margin-bottom: -1 * $hint-arrowBorderWidth;
 	}
 
 	&:after {
 		// bring back to center
-		margin-bottom: -1 * floor($tooltipHeight / 2);
+		margin-bottom: -1 * floor($hint-tooltipHeight / 2);
 	}
 
 	&:before, &:after {
@@ -72,40 +72,40 @@
 /**
  * set default color for tooltip arrows
  */
-@include arrow-border-color($defaultColor);
+@include arrow-border-color($hint-defaultColor);
 
 /**
  * top tooltip
  */
-.#{$prefix}top {
+.#{$hint-prefix}top {
 	@include vertical-positioned-tooltip('bottom', -1);
 }
 
 /**
  * bottom tooltip
  */
-.#{$prefix}bottom {
+.#{$hint-prefix}bottom {
 	@include vertical-positioned-tooltip('top', 1);
 }
 
 /**
  * right tooltip
  */
-.#{$prefix}right {
+.#{$hint-prefix}right {
 	@include horizontal-positioned-tooltip('left', 1);
 }
 
 /**
  * left tooltip
  */
-.#{$prefix}left {
+.#{$hint-prefix}left {
 	@include horizontal-positioned-tooltip('right', -1);
 }
 
 /**
  * top-left tooltip
  */
-.#{$prefix}top-left {
+.#{$hint-prefix}top-left {
 	@include vertical-positioned-tooltip('bottom', -1, -1);
 }
 
@@ -113,14 +113,14 @@
 /**
  * top-right tooltip
  */
-.#{$prefix}top-right {
+.#{$hint-prefix}top-right {
 	@include vertical-positioned-tooltip('bottom', -1, 1);
 }
 
 /**
  * bottom-left tooltip
  */
-.#{$prefix}bottom-left {
+.#{$hint-prefix}bottom-left {
 	@include vertical-positioned-tooltip('top', 1, -1);
 }
 
@@ -128,6 +128,6 @@
 /**
  * bottom-right tooltip
  */
-.#{$prefix}bottom-right {
+.#{$hint-prefix}bottom-right {
 	@include vertical-positioned-tooltip('top', 1, 1);
 }

--- a/src/hint-rounded.scss
+++ b/src/hint-rounded.scss
@@ -8,7 +8,7 @@
  *
  */
 
-.#{$hint-prefix}rounded {
+.#{$hintPrefix}rounded {
 	&:after {
 		border-radius: 4px;
 	}

--- a/src/hint-rounded.scss
+++ b/src/hint-rounded.scss
@@ -8,7 +8,7 @@
  *
  */
 
-.#{$prefix}rounded {
+.#{$hint-prefix}rounded {
 	&:after {
 		border-radius: 4px;
 	}

--- a/src/hint-theme.scss
+++ b/src/hint-theme.scss
@@ -10,7 +10,7 @@
 	 * tooltip body
 	 */
 	&:after {
-		text-shadow: 0 -1px 0px darken($hint-defaultColor, $hint-textShadowDarkenAmount);
+		text-shadow: 0 -1px 0px darken($hintDefaultColor, $hintTextShadowDarkenAmount);
 		box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.3);
 	}
 }

--- a/src/hint-theme.scss
+++ b/src/hint-theme.scss
@@ -10,7 +10,7 @@
 	 * tooltip body
 	 */
 	&:after {
-		text-shadow: 0 -1px 0px darken($defaultColor, $textShadowDarkenAmount);
+		text-shadow: 0 -1px 0px darken($hint-defaultColor, $hint-textShadowDarkenAmount);
 		box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.3);
 	}
 }

--- a/src/hint-variables.scss
+++ b/src/hint-variables.scss
@@ -3,52 +3,52 @@
 // Declares some variables used within the library.
 
 // Prefix for all classes. By default, BEM naming convention is used
-$prefix: 'hint--' !default;
+$hint-prefix: 'hint--' !default;
 
 // font size
-$fontSize: 12px;
+$hint-fontSize: 12px;
 
 // paddings
-$verticalPadding: 8px;
-$horizontalPadding: 10px;
+$hint-verticalPadding: 8px;
+$hint-horizontalPadding: 10px;
 
 // default tooltip height
-$tooltipHeight: $fontSize + 2 * $verticalPadding !default;
+$hint-tooltipHeight: $hint-fontSize + 2 * $hint-verticalPadding !default;
 
 // border-width for tooltip arrow
-$arrowBorderWidth: 6px !default;
+$hint-arrowBorderWidth: 6px !default;
 
 // horizontal arrow offset
-$arrowOffsetX: 1 * $arrowBorderWidth !default;
+$hint-arrowOffsetX: 1 * $hint-arrowBorderWidth !default;
 
 // text-shadow darken percentage
-$textShadowDarkenAmount: 25% !default;
+$hint-textShadowDarkenAmount: 25% !default;
 
 // transition distance
-$transitionDistance: 8px !default;
+$hint-transitionDistance: 8px !default;
 
 // Delay in showing the tooltips.
-$showDelay: 100ms !default;
+$hint-showDelay: 100ms !default;
 
 // Delay in hiding the tooltips.
-$hideDelay: 0ms !default;
+$hint-hideDelay: 0ms !default;
 
 // z-index for tooltips
-$zIndex: 1000000 !default;
+$hint-zIndex: 1000000 !default;
 
 
 // Various colors
 // Default color is blackish
-$defaultColor: hsl(0, 0%, 22%) !default;
+$hint-defaultColor: hsl(0, 0%, 22%) !default;
 
 // Error color
-$errorColor: hsl(1, 40%, 50%) !default;
+$hint-errorColor: hsl(1, 40%, 50%) !default;
 
 // Warning color
-$warningColor: hsl(38, 46%, 54%) !default;
+$hint-warningColor: hsl(38, 46%, 54%) !default;
 
 // Info Color
-$infoColor: hsl(200, 50%, 45%) !default;
+$hint-infoColor: hsl(200, 50%, 45%) !default;
 
 // Success Color
-$successColor: hsl(121, 32%, 40%) !default;
+$hint-successColor: hsl(121, 32%, 40%) !default;

--- a/src/hint-variables.scss
+++ b/src/hint-variables.scss
@@ -3,52 +3,52 @@
 // Declares some variables used within the library.
 
 // Prefix for all classes. By default, BEM naming convention is used
-$hint-prefix: 'hint--' !default;
+$hintPrefix: 'hint--' !default;
 
 // font size
-$hint-fontSize: 12px;
+$hintFontSize: 12px;
 
 // paddings
-$hint-verticalPadding: 8px;
-$hint-horizontalPadding: 10px;
+$hintVerticalPadding: 8px;
+$hintHorizontalPadding: 10px;
 
 // default tooltip height
-$hint-tooltipHeight: $hint-fontSize + 2 * $hint-verticalPadding !default;
+$hintTooltipHeight: $hintFontSize + 2 * $hintVerticalPadding !default;
 
 // border-width for tooltip arrow
-$hint-arrowBorderWidth: 6px !default;
+$hintArrowBorderWidth: 6px !default;
 
 // horizontal arrow offset
-$hint-arrowOffsetX: 1 * $hint-arrowBorderWidth !default;
+$hintArrowOffsetX: 1 * $hintArrowBorderWidth !default;
 
 // text-shadow darken percentage
-$hint-textShadowDarkenAmount: 25% !default;
+$hintTextShadowDarkenAmount: 25% !default;
 
 // transition distance
-$hint-transitionDistance: 8px !default;
+$hintTransitionDistance: 8px !default;
 
 // Delay in showing the tooltips.
-$hint-showDelay: 100ms !default;
+$hintShowDelay: 100ms !default;
 
 // Delay in hiding the tooltips.
-$hint-hideDelay: 0ms !default;
+$hintHideDelay: 0ms !default;
 
 // z-index for tooltips
-$hint-zIndex: 1000000 !default;
+$hintZIndex: 1000000 !default;
 
 
 // Various colors
 // Default color is blackish
-$hint-defaultColor: hsl(0, 0%, 22%) !default;
+$hintDefaultColor: hsl(0, 0%, 22%) !default;
 
 // Error color
-$hint-errorColor: hsl(1, 40%, 50%) !default;
+$hintErrorColor: hsl(1, 40%, 50%) !default;
 
 // Warning color
-$hint-warningColor: hsl(38, 46%, 54%) !default;
+$hintWarningColor: hsl(38, 46%, 54%) !default;
 
 // Info Color
-$hint-infoColor: hsl(200, 50%, 45%) !default;
+$hintInfoColor: hsl(200, 50%, 45%) !default;
 
 // Success Color
-$hint-successColor: hsl(121, 32%, 40%) !default;
+$hintSuccessColor: hsl(121, 32%, 40%) !default;


### PR DESCRIPTION
Added the prefix `hint-` to all variables, useful when including hint.css with your own sass code, to prevent any variable clashes.