### PR TITLE
Use !default for all variables

### DIFF
--- a/src/hint-variables.scss
+++ b/src/hint-variables.scss
@@ -6,11 +6,11 @@
 $prefix: 'hint--' !default;
 
 // font size
-$fontSize: 12px;
+$fontSize: 12px !default;
 
 // paddings
-$verticalPadding: 8px;
-$horizontalPadding: 10px;
+$verticalPadding: 8px !default;
+$horizontalPadding: 10px !default;
 
 // default tooltip height
 $tooltipHeight: $fontSize + 2 * $verticalPadding !default;


### PR DESCRIPTION
I'm not sure if there was a reason for skipping these but I think all variables should be overridable the same way. `!default` makes is so that the value is only set if the variable is not already set