### PR TITLE
Populate tooltip content using the aria-label attribute

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -263,43 +263,43 @@
 				<div class="window">
 					<div class="titlebar">
 						<div class="buttons">
-							<a class="titlebar__btn  close  hint--bottom-right" data-hint="Close"></a>
-							<a class="titlebar__btn  minimize  hint--bottom-right" data-hint="Minimize"></a>
-							<a class="titlebar__btn  zoom  hint--bottom-right" data-hint="Zoom"></a>
+							<a class="titlebar__btn  close  hint--bottom-right" aria-label="Close"></a>
+							<a class="titlebar__btn  minimize  hint--bottom-right" aria-label="Minimize"></a>
+							<a class="titlebar__btn  zoom  hint--bottom-right" aria-label="Zoom"></a>
 						</div>
 						Try hovering over different things
 					</div>
 					<div class="content">
 						<div class="position-grid">
-							<div class="position-grid__cell"><a href="#" data-hint="bottom-right" class="hint--bottom-right">bottom-right</a></div>
-							<div class="position-grid__cell"><a href="#" data-hint="bottom" class="hint--bottom">bottom</a></div>
-							<div class="position-grid__cell"><a href="#" data-hint="bottom-left" class="hint--bottom-left">bottom-left</a></div>
-							<div class="position-grid__cell"><a href="#" data-hint="right" class="hint--right">right</a></div>
+							<div class="position-grid__cell"><a href="#" aria-label="bottom-right" class="hint--bottom-right">bottom-right</a></div>
+							<div class="position-grid__cell"><a href="#" aria-label="bottom" class="hint--bottom">bottom</a></div>
+							<div class="position-grid__cell"><a href="#" aria-label="bottom-left" class="hint--bottom-left">bottom-left</a></div>
+							<div class="position-grid__cell"><a href="#" aria-label="right" class="hint--right">right</a></div>
 							<div class="position-grid__cell"><a>.</a></div>
-							<div class="position-grid__cell"><a href="#" data-hint="left" class="hint--left">left</a></div>
-							<div class="position-grid__cell"><a href="#" data-hint="top-right" class="hint--top-right">top-right</a></div>
-							<div class="position-grid__cell"><a href="#" data-hint="top" class="hint--top">top</a></div>
-							<div class="position-grid__cell"><a href="#" data-hint="top-left" class="hint--top-left">top-left</a></div>
+							<div class="position-grid__cell"><a href="#" aria-label="left" class="hint--left">left</a></div>
+							<div class="position-grid__cell"><a href="#" aria-label="top-right" class="hint--top-right">top-right</a></div>
+							<div class="position-grid__cell"><a href="#" aria-label="top" class="hint--top">top</a></div>
+							<div class="position-grid__cell"><a href="#" aria-label="top-left" class="hint--top-left">top-left</a></div>
 						</div>
 
 						<h3>Color Modifiers</h3>
 						<p>
-							<a class="status-icon  hint--bottom-right  hint--error" style="background:indianred" data-hint="This is an error tooltip">
+							<a class="status-icon  hint--bottom-right  hint--error" style="background:indianred" aria-label="This is an error tooltip">
 								<svg style="width:24px;height:24px" viewBox="0 0 24 24">
 										<path fill="#ffffff" d="M8.27,3L3,8.27V15.73L8.27,21H15.73L21,15.73V8.27L15.73,3M8.41,7L12,10.59L15.59,7L17,8.41L13.41,12L17,15.59L15.59,17L12,13.41L8.41,17L7,15.59L10.59,12L7,8.41" />
 								</svg>
 							</a>
-							<a class="status-icon  hint--bottom-right  hint--warning" style="background:orange" data-hint="This is a warning tooltip">
+							<a class="status-icon  hint--bottom-right  hint--warning" style="background:orange" aria-label="This is a warning tooltip">
 								<svg style="width:24px;height:24px" viewBox="0 0 24 24">
 										<path fill="#ffffff" d="M11,4.5H13V15.5H11V4.5M13,17.5V19.5H11V17.5H13Z" />
 								</svg>
 							</a>
-							<a class="status-icon  hint--bottom-left  hint--info" style="background:lightblue" data-hint="This is an info tooltip">
+							<a class="status-icon  hint--bottom-left  hint--info" style="background:lightblue" aria-label="This is an info tooltip">
 								<svg style="width:24px;height:24px" viewBox="0 0 24 24">
 										<path fill="#ffffff" d="M12,2A7,7 0 0,1 19,9C19,11.38 17.81,13.47 16,14.74V17A1,1 0 0,1 15,18H9A1,1 0 0,1 8,17V14.74C6.19,13.47 5,11.38 5,9A7,7 0 0,1 12,2M9,21V20H15V21A1,1 0 0,1 14,22H10A1,1 0 0,1 9,21M12,4A5,5 0 0,0 7,9C7,11.05 8.23,12.81 10,13.58V16H14V13.58C15.77,12.81 17,11.05 17,9A5,5 0 0,0 12,4Z" />
 								</svg>
 							</a>
-							<a class="status-icon  hint--bottom-right  hint--success" style="background:lightgreen" data-hint="This is success tooltip">
+							<a class="status-icon  hint--bottom-right  hint--success" style="background:lightgreen" aria-label="This is success tooltip">
 								<svg style="width:24px;height:24px" viewBox="0 0 24 24">
 									<path fill="#ffffff" d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
 								</svg>
@@ -309,20 +309,20 @@
 						<h3>Extra</h3>
 
 						<p>
-							<a class="hint--left  hint--always" data-hint="...which always keep showing">You can also make tooltips...</a>
+							<a class="hint--left  hint--always" aria-label="...which always keep showing">You can also make tooltips...</a>
 						</p>
 
 						<p>
-							<a class="hint--top  hint--rounded" data-hint="We have rounded corners for you">Hmm...So you don't like sharp edges?</a>
+							<a class="hint--top  hint--rounded" aria-label="We have rounded corners for you">Hmm...So you don't like sharp edges?</a>
 						</p>
 
 						<h3>Effects</h3>
 
 						<p>
-							<a class="hint--top  hint--no-animate" data-hint="Get a simple show/hide tooltip">Dont like animation?</a>
+							<a class="hint--top  hint--no-animate" aria-label="Get a simple show/hide tooltip">Dont like animation?</a>
 						</p>
 						<p>
-							<a class="hint--right  hint--bounce" data-hint="Bounce">Adding a <code>hint--bounce</code> class gives you that...</a>
+							<a class="hint--right  hint--bounce" aria-label="Bounce">Adding a <code>hint--bounce</code> class gives you that...</a>
 						</p>
 					</div>
 				</div>

--- a/hint.base.css
+++ b/hint.base.css
@@ -24,7 +24,7 @@
  * Classes added:
  * 	1) hint
  */
-[data-hint] {
+[class*="hint--"] {
   position: relative;
   display: inline-block;
   /**
@@ -33,7 +33,7 @@
   /**
 	 * tooltip body
 	 */ }
-  [data-hint]:before, [data-hint]:after {
+  [class*="hint--"]:before, [class*="hint--"]:after {
     position: absolute;
     -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0);
@@ -48,21 +48,21 @@
     -webkit-transition-delay: 0ms;
     -moz-transition-delay: 0ms;
     transition-delay: 0ms; }
-  [data-hint]:hover:before, [data-hint]:hover:after {
+  [class*="hint--"]:hover:before, [class*="hint--"]:hover:after {
     visibility: visible;
     opacity: 1; }
-  [data-hint]:hover:before, [data-hint]:hover:after {
+  [class*="hint--"]:hover:before, [class*="hint--"]:hover:after {
     -webkit-transition-delay: 100ms;
     -moz-transition-delay: 100ms;
     transition-delay: 100ms; }
-  [data-hint]:before {
+  [class*="hint--"]:before {
     content: '';
     position: absolute;
     background: transparent;
     border: 6px solid transparent;
     z-index: 1000001; }
-  [data-hint]:after {
-    content: attr(data-hint);
+  [class*="hint--"]:after {
+    content: attr(aria-label);
     background: #383838;
     color: white;
     padding: 8px 10px;
@@ -71,7 +71,7 @@
     line-height: 12px;
     white-space: nowrap; }
 
-[data-hint='']:before, [data-hint='']:after {
+[aria-label='']:before, [aria-label='']:after {
   display: none !important; }
 
 /**

--- a/hint.css
+++ b/hint.css
@@ -24,7 +24,7 @@
  * Classes added:
  * 	1) hint
  */
-[data-hint] {
+[class*="hint--"] {
   position: relative;
   display: inline-block;
   /**
@@ -33,7 +33,7 @@
   /**
 	 * tooltip body
 	 */ }
-  [data-hint]:before, [data-hint]:after {
+  [class*="hint--"]:before, [class*="hint--"]:after {
     position: absolute;
     -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0);
@@ -48,21 +48,21 @@
     -webkit-transition-delay: 0ms;
     -moz-transition-delay: 0ms;
     transition-delay: 0ms; }
-  [data-hint]:hover:before, [data-hint]:hover:after {
+  [class*="hint--"]:hover:before, [class*="hint--"]:hover:after {
     visibility: visible;
     opacity: 1; }
-  [data-hint]:hover:before, [data-hint]:hover:after {
+  [class*="hint--"]:hover:before, [class*="hint--"]:hover:after {
     -webkit-transition-delay: 100ms;
     -moz-transition-delay: 100ms;
     transition-delay: 100ms; }
-  [data-hint]:before {
+  [class*="hint--"]:before {
     content: '';
     position: absolute;
     background: transparent;
     border: 6px solid transparent;
     z-index: 1000001; }
-  [data-hint]:after {
-    content: attr(data-hint);
+  [class*="hint--"]:after {
+    content: attr(aria-label);
     background: #383838;
     color: white;
     padding: 8px 10px;
@@ -71,7 +71,7 @@
     line-height: 12px;
     white-space: nowrap; }
 
-[data-hint='']:before, [data-hint='']:after {
+[aria-label='']:before, [aria-label='']:after {
   display: none !important; }
 
 /**

--- a/src/hint-core.scss
+++ b/src/hint-core.scss
@@ -10,7 +10,7 @@
  * 	1) hint
  */
 
-[data-hint] {
+[class*="hint--"] {
 	position: relative;
 	display: inline-block;
 
@@ -60,7 +60,7 @@
 	 * tooltip body
 	 */
 	&:after {
-		content: attr(data-hint); // The magic!
+		content: attr(aria-label); // The magic!
 		background: $hintDefaultColor;
 		color: white;
 		padding: $hintVerticalPadding $hintHorizontalPadding;
@@ -71,7 +71,7 @@
 	}
 }
 
-[data-hint=''] {
+[aria-label=''] {
 	&:before, &:after {
 		display: none !important;
 	}


### PR DESCRIPTION
Hi @chinchang!

Copying some notes from [my original issue comment](https://github.com/chinchang/hint.css/issues/81#issuecomment-178041305):

You'll see that using `aria-label` instead of `data-hint` has the same results:

<img width="562" alt="screen shot 2016-02-01 at 10 24 25 am" src="https://cloud.githubusercontent.com/assets/287268/12722150/933ddab4-c8d1-11e5-8444-ee98785916cd.png">

But the tooltip's contents are now accessible to screen-readers:

<img width="819" alt="screen shot 2016-02-01 at 10 25 06 am" src="https://cloud.githubusercontent.com/assets/287268/12722175/af3892c2-c8d1-11e5-9ba9-0c23ca8a47ac.png">

**These changes follow the assumption that the tooltip is labeling the element it is annotating**. This means that screen-readers will not read off the actual content of the element itself, but only its tooltip. 

Consider the following:

![image](https://cloud.githubusercontent.com/assets/287268/12722301/4536a480-c8d2-11e5-9723-5febc877a05c.png)

In the above scenario, "Checkout" will be omitted in favor of "You will be charged $5.00" by the screen-reader. 