### PR TITLE
Prevent long words from overflowing

### DIFF
--- a/src/hint-sizes.scss
+++ b/src/hint-sizes.scss
@@ -18,6 +18,7 @@
 	&:after {
 		white-space: normal;
 		line-height: 1.4em;
+		word-wrap: break-word; // Ensure long words do not overflow.
 	}
 }
 


### PR DESCRIPTION
Ran into this issue with user-generated text that overflowed the tooltip.

Before:

<img width="343" alt="screenshot 2016-07-27 09 53 20" src="https://cloud.githubusercontent.com/assets/38203/17179773/fa028e54-53df-11e6-95ae-4ee203cc8e04.png">

After:

<img width="179" alt="screenshot 2016-07-27 09 53 06" src="https://cloud.githubusercontent.com/assets/38203/17179780/fe1245ca-53df-11e6-8493-143882fe77d9.png">
