### PR TITLE
fix broken jsdelivr cdn link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Get the library using one of the following ways:
 
 3. **npm**: `npm install --save hint.css`
 
-4. **CDN**: [http://www.jsdelivr.com/#!hint.css](http://www.jsdelivr.com/#!hint.css) or [https://cdnjs.com/libraries/hint.css](https://cdnjs.com/libraries/hint.css)
+4. **CDN**: [https://www.jsdelivr.com/package/npm/hint.css](https://www.jsdelivr.com/package/npm/hint.css) or [https://cdnjs.com/libraries/hint.css](https://cdnjs.com/libraries/hint.css)
 
 Now include the library in the ``HEAD`` tag of your page:
 


### PR DESCRIPTION
For 'http://www.jsdelivr.com/#!hint.css' wrongly resolves to 'https://www.jsdelivr.com/package/npm/hint', changed old link to 'https://www.jsdelivr.com/package/npm/hint.css', which is full correct link of this project.